### PR TITLE
[Fix] Server crash due to connection failure

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -223,8 +223,8 @@ export class YandexPlatform implements DynamicPlatformPlugin {
 			url: "https://api.iot.yandex.net/v1.0/user/info"
 		})
 
-
-		if (devices_res.data.status === "ok") {
+		// Checking that its not null in case if requests failes and no data recieved, so it would be ignored
+		if (devices_res !== null && devices_res !== undefined && devices_res.data.status === "ok") {
 			for (const device of devices_res.data.devices) {
 				const accessory = this.accessories.find(
 					(a) => a.UUID === device.id


### PR DESCRIPTION
**Problem:** Server crashed with error trying to access devices_res.data.status. It appears that requestYandexAPI method return nil if connection fails.
**Solution:** To handle that case I've added checks that it's not nil or undefined first. I've tested with loss of internet connection and server kept running and fetched new date once Internet become available.